### PR TITLE
Fix Dropdown for Rich Text Editor in the Inspector missing options

### DIFF
--- a/packages/react-ui-components/src/DropDown/style.css
+++ b/packages/react-ui-components/src/DropDown/style.css
@@ -49,7 +49,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: var(--zIndex-DropdownContents-Context);
+    z-index: var(--zIndex-SecondaryInspectorElevated-DropDownContents);
     display: none;
     width: 100%;
     margin: 0;


### PR DESCRIPTION
When editing a rich text editor content in the inspector, as soon as content is changed the element is promoted to a higher z-index for unpublished changes. This results in the standard dropdown contents being hidden behind the editor. This updates the dropdown z-index to use the --zIndex-SecondaryInspectorElevated-DropDownContents for the dropdown contents to fix the issue.

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
